### PR TITLE
fix: Relax recommended config to work also with libraries

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -8,7 +8,7 @@ module.exports = {
 		'@nextcloud',
 	],
 	rules: {
-		'@nextcloud/no-deprecations': ['warn', { parseAppInfo: true }],
-		'@nextcloud/no-removed-apis': ['error', { parseAppInfo: true }],
+		'@nextcloud/no-deprecations': ['warn'],
+		'@nextcloud/no-removed-apis': ['error'],
 	},
 };

--- a/lib/utils/version-parser.js
+++ b/lib/utils/version-parser.js
@@ -71,7 +71,7 @@ function createVersionValidator({ cwd, physicalFilename, options }) {
 	}
 
 	// Try to find appinfo and parse the supported version
-	if (settings?.parseAppInfo) {
+	if (settings?.parseAppInfo !== false) {
 		// Current working directory, either the filename (can be empty) or the cwd property
 		const currentDirectory = path.isAbsolute(physicalFilename)
 			? path.resolve(path.dirname(physicalFilename))
@@ -92,7 +92,11 @@ function createVersionValidator({ cwd, physicalFilename, options }) {
 			maxVersion = sanitizeTargetVersion(maxVersion)
 			return (version) => semver.lte(version, maxVersion)
 		}
-		throw Error('[@nextcloud/eslint-plugin] AppInfo parsing was enabled, but no `appinfo/info.xml` was found.')
+
+		if (settings?.parseAppInfo === true) {
+			// User enforced app info parsing, so we throw an error - otherwise just fallback to default
+			throw Error('[@nextcloud/eslint-plugin] AppInfo parsing was enabled, but no `appinfo/info.xml` was found.')
+		}
 	}
 
 	// If not configured or parsing is disabled, every rule should be handled


### PR DESCRIPTION
If app info parsing was not explicitly enabled we still default to do it, but if no app info is found we do not fail but default to previous behavior of enabling all rules.